### PR TITLE
defect/montserrat-continent

### DIFF
--- a/src/assets/data/countries.json
+++ b/src/assets/data/countries.json
@@ -746,7 +746,7 @@
   },
   {
     "name": "Montserrat",
-    "continent": "Oceania",
+    "continent": "North America",
     "latlng": ["16.75", "-62.2"]
   },
   {


### PR DESCRIPTION
https://trello.com/c/Qgsx1ahq

- Fix Montserrat continent from `Oceania` to `North America`

<img width="859" alt="Screenshot 2025-04-07 at 5 52 45 PM" src="https://github.com/user-attachments/assets/82b3a4e1-3253-4406-987a-1b0a810ef3fd" />
